### PR TITLE
Update Generic Signed Payload

### DIFF
--- a/Generic Signed Payload
+++ b/Generic Signed Payload
@@ -35,7 +35,11 @@ One possible solution is to sign every message entered. Nodes do not have to che
 
 This solution has not been accepted by the developer community, which is essentially asking for the signature to be included in the Layer 2 payload.
 
-This option is certainly viable, but since each Layer 2 application has its own payload format, in order to avoid error confusion, to simplify the applications themselves and to reduce as much as possible the effort of Layer 2 applications in validating their messages, it is desirable to at least introduce an "applciation type" field at Layer 1, the equivalent of the "protocol" field of the IP network protocol.
+This option is certainly viable, but since each Layer 2 application has its own payload format, in order to avoid errors, ambiguity, confusion, to simplify the applications themselves and to reduce as much as possible the effort of Layer 2 applications in validating their messages, it is desirable to at least introduce an "applciation type" field at Layer 1, the equivalent of the "protocol" field of the IP network protocol.
+
+An application receiving the block stream from the node can easily apply a filter and choose only the blocks of the Data Payload type and then choose only those that have a specific the Payload Type. 
+Finally, each payload type will have its own structure described in appropriate TIPs: the receiving application can either apply payload validation logic and process it, or discard the block if the payload is invalid.
+
 
 ## Specification
 
@@ -63,9 +67,6 @@ Layer 2 Payload type table
 | 4            | STREAMS payload                                                                           |
 
 Other Values type can be added on request.
-Each Payload type need a dedicated TIP describing the Layer 2 serialization layout
-
-
 
 ## Rationale
 This is a very simple soltution to allow to build Layer 2 applications that discriminate the Layer 1 content and discard any block not cointaining useful data.

--- a/Generic Signed Payload
+++ b/Generic Signed Payload
@@ -22,7 +22,7 @@ This document proposes a basic Layer 1 payload type that include a layer 2 conte
 
 IOTA provides the very useful feature of publishing no-cost blocks that may contain data. The registry thus becomes a reliable transport layer for sending data, i.e., a layer on which to base the design of applications that require maximum reliability in sending data.
 
-Of course, the registry cannot indefinitely hold all data that is published, so nodes must remove these blocks from their databases.
+Of course, the ledger cannot indefinitely hold all data that is published, so nodes must remove these blocks from their databases.
 
 This in part nullifies the advantage of the network for the transmission of critical data because the receiver has to worry about always being listening and not missing any message intended for him. 
 

--- a/Generic Signed Payload
+++ b/Generic Signed Payload
@@ -62,7 +62,7 @@ Layer 2 Payload type table
 | 3            | Distributed Identity application payload                                                  |
 | 4            | STREAMS payload                                                                           |
 
-Other Value type can be added on request.
+Other Values type can be added on request.
 Each Payload type need a dedicated TIP descibing the Layer 2 serialization layout
 
 

--- a/Generic Signed Payload
+++ b/Generic Signed Payload
@@ -1,7 +1,7 @@
 ---
 tip: <to be assigned>
-title: <Signed Tagged Data Paload>
-description: <Standard format of a Tangle message containing a payload signed by the publisher>
+title: <Data Paload>
+description: <Standard format of a Tangle message containing a data payload>
 author: <Stefano Della Valle (@sdellava)>
 discussions-to: <https://github.com/iotaledger/tips/discussions/100>
 status: Draft
@@ -15,14 +15,27 @@ superseded-by (*optional): <TIP number(s)>
 
 ## Abstract
 
-The payload concept offers a very flexible way to combine and encapsulate information in the IOTA protocol. This document proposes a basic singed payload type that allows the addition of arbitrary signed data.
+The payload concept offers a very flexible way to combine and encapsulate information in the IOTA protocol. 
+This document proposes a basic payload type that include a layer 2 content type identification field.
 
 ## Motivation
 
-To support low-cost applications we need to create a selective permanode inx plug-in, and to make it reliable we need a standard method for identifying fake blocks.
+IOTA provides the very useful feature of publishing no-cost blocks that may contain data. The registry thus becomes a reliable transport layer for sending data, i.e., a layer on which to base the design of applications that require maximum reliability in sending data.
 
-This TIP is intended to define a block payload format that can be recognized as true or false by a standard method.
+Of course, the registry cannot indefinitely hold all data that is published, so nodes must remove these blocks from their databases.
 
+This in part nullifies the advantage of the network for the transmission of critical data because the receiver has to worry about always being listening and not missing any message intended for him. 
+
+There are three critical points in the current system:
+- using a permanode to store all traffic is too expensive
+- receiving and analyzing all traffic with a layer 2 application is potentially very expensive anyway
+- using the tag field as a discrinant only partially solves the problem because anyone can post messages with that tag, forcing the application to perform an application check.
+
+One possible solution is to sign every message entered. Nodes do not have to check the signature, so there would be no impact on the network, but this would allow a generic layer 2 application to understand that the message is invalid without even getting into the meaning of the payload. Spam messages would be easily discarded minimizing the overload on the Layer 2 application.
+
+This solution has not been accepted by the developer community, which is essentially asking for the signature to be included in the payload.
+
+This option is certainly viable, but since each Layer 2 application has its own payload format, in order to avoid error confusion, to simplify the applications themselves, and to reduce as much as possible the effort of applications in validating their messages, it is desirable to at least introduce an "applciation type" field at Layer 1, the equivalent of the "protocol" field of the IP network protocol.
 
 ## Specification
 
@@ -32,30 +45,35 @@ Serialized Layout
 
 The following table describes the serialization of Data field of a _Singed Tagged Data Payload_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
 
-| Name         | Type              | Description                                                                               |
-|--------------|-------------------|-------------------------------------------------------------------------------------------|
-| Payload Type | uint32            | Set to *value 6* to denote an _Signed Data Payload_.                                      |
-| Tag          | (uint8)ByteArray  | The tag of the data. A leading uint8 denotes its length.                                  |
-| Public key   | ByteArray[32]     | The public key of the Ed25519 keypair which is used to verify the correspondig signature. |
-| Singature    | ByteArray[64]     | Ed25519 signature signing the BLAKE2b-256 hash of the Data                                |
-| Data         | (uint32)ByteArray | Binary data. A leading uint32 denotes its length.                                         |
+| Name                 | Type              | Description                                                                               |
+|----------------------|-------------------|-------------------------------------------------------------------------------------------|
+| Payload Type         | uint32            | Set to *value N* (where N is to be defined) to denote an _Data Payload_.                  |
+| Layer 2 Payload type | unit32            | Set to a value according the Layer 2 Payload type table.                                             |
+| Data                 | (uint32)ByteArray | Binary data. A leading uint32 denotes its length.                                         |
 
-It is important to note that `Tag`, `Public key` and `Signature` are not considered by the protocol, they just serves as a marker for second layer applications.
 
-## Syntactic Validation
+Layer 2 Payload type table
 
-- `length(Tag)` must not be larger than [`Max Tag Length`](../TIP-0022/tip-0022.md).
-- Given the type and length information, the _Singed Tagged Data Payload_ must consume the entire byte array of the `Payload` field of the encapsulating object.
+| Value        | Description                                                                               |
+|--------------|-------------------------------------------------------------------------------------------|
+| 0            | Generic unstructured payload                                                              |
+| 1            | Tagged Data Payload (can replace the Layer 1 Tagged Payload)                              |
+| 2            | Tagged Signed Data Payload                                                                |
+| 3            | Distributed Identity application payload                                                  |
+| 4            | STREAMS payload                                                                           |
+
+Other Value type can be added on request.
+Each Payload type need a dedicated TIP descibing the Layer 2 serialization layout
+
 
 
 ## Rationale
-This is a very simple soltution to allow to build selective permanodes and basic application that share data over the tangle with enough reliability.
+This is a very simple soltution to allow to build Layer 2 applications that discriminate the Layer 1 content and discard any block not cointaining useful data.
 
 ## Backwards Compatibility
 Not relevant
 
 ## Test Cases
-The test case is the implementation of the INX Selective Permanode
 
 
 ## Copyright

--- a/Generic Signed Payload
+++ b/Generic Signed Payload
@@ -43,7 +43,7 @@ Detailed design
 
 Serialized Layout
 
-The following table describes the serialization of Data field of a _Singed Tagged Data Payload_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
+The following table describes the serialization of Data field of a _Generic Data Payload_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
 
 | Name                 | Type              | Description                                                                               |
 |----------------------|-------------------|-------------------------------------------------------------------------------------------|

--- a/Generic Signed Payload
+++ b/Generic Signed Payload
@@ -16,7 +16,7 @@ superseded-by (*optional): <TIP number(s)>
 ## Abstract
 
 The payload concept offers a very flexible way to combine and encapsulate information in the IOTA protocol. 
-This document proposes a basic payload type that include a layer 2 content type identification field.
+This document proposes a basic Layer 1 payload type that include a layer 2 content type identification field.
 
 ## Motivation
 

--- a/Generic Signed Payload
+++ b/Generic Signed Payload
@@ -33,9 +33,9 @@ There are three critical points in the current system:
 
 One possible solution is to sign every message entered. Nodes do not have to check the signature, so there would be no impact on the network, but this would allow a generic layer 2 application to understand that the message is invalid without even getting into the meaning of the payload. Spam messages would be easily discarded minimizing the overload on the Layer 2 application.
 
-This solution has not been accepted by the developer community, which is essentially asking for the signature to be included in the payload.
+This solution has not been accepted by the developer community, which is essentially asking for the signature to be included in the Layer 2 payload.
 
-This option is certainly viable, but since each Layer 2 application has its own payload format, in order to avoid error confusion, to simplify the applications themselves, and to reduce as much as possible the effort of applications in validating their messages, it is desirable to at least introduce an "applciation type" field at Layer 1, the equivalent of the "protocol" field of the IP network protocol.
+This option is certainly viable, but since each Layer 2 application has its own payload format, in order to avoid error confusion, to simplify the applications themselves and to reduce as much as possible the effort of Layer 2 applications in validating their messages, it is desirable to at least introduce an "applciation type" field at Layer 1, the equivalent of the "protocol" field of the IP network protocol.
 
 ## Specification
 

--- a/Generic Signed Payload
+++ b/Generic Signed Payload
@@ -63,7 +63,7 @@ Layer 2 Payload type table
 | 4            | STREAMS payload                                                                           |
 
 Other Values type can be added on request.
-Each Payload type need a dedicated TIP descibing the Layer 2 serialization layout
+Each Payload type need a dedicated TIP describing the Layer 2 serialization layout
 
 
 

--- a/Generic Signed Payload
+++ b/Generic Signed Payload
@@ -1,7 +1,7 @@
 ---
 tip: <to be assigned>
 title: <Data Paload>
-description: <Standard format of a Tangle message containing a data payload>
+description: <Standard format of a Tangle block containing a data payload>
 author: <Stefano Della Valle (@sdellava)>
 discussions-to: <https://github.com/iotaledger/tips/discussions/100>
 status: Draft
@@ -43,7 +43,7 @@ Detailed design
 
 Serialized Layout
 
-The following table describes the serialization of Data field of a _Generic Data Payload_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
+The following table describes the serialization of Data field of a _Data Payload_ following the notation from [TIP-21](../TIP-0021/tip-0021.md):
 
 | Name                 | Type              | Description                                                                               |
 |----------------------|-------------------|-------------------------------------------------------------------------------------------|


### PR DESCRIPTION
As a result of the various discussions we had regarding the need to improve the usability of the network for sending generic data, I have drafted a new TIP.

I hope this proposal is clear in its intent to simplify the implementation of standard layer 2 application protocols and applications, thus making the IOTA network more easily adoptable for the widest number of applications.
